### PR TITLE
Migrating the perl5 Tool from bitbucket to git

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,13 @@
+SCons tool for perl5 scripts and modules
+========================================
+
+To use it, drop the `perl5` directory on the `site_scons/site_tools`
+(from the root of your project).  You will then want something similar
+to this on your SConscript file:
+
+    env = Environment(PERL5LIB=['lib-perl5'])
+    env.Tool('perl5')
+
+We do not really do the parsing of dependencies ourselves, there's
+perl modules for this.  We make use of the Module::ScanDeps perl
+module to find our dependencies.

--- a/README
+++ b/README
@@ -5,7 +5,7 @@ To use it, drop the `perl5` directory on the `site_scons/site_tools`
 (from the root of your project).  You will then want something similar
 to this on your SConscript file:
 
-    env = Environment(PERL5LIB=['lib-perl5'])
+    env = Environment(PERL5LIB=[Dir('lib-perl5'])
     env.Tool('perl5')
 
 We do not really do the parsing of dependencies ourselves, there's

--- a/perl5/__init__.py
+++ b/perl5/__init__.py
@@ -76,9 +76,11 @@ def CheckPerlModule(context, module_name):
 
 def generate(env):
   vars = SCons.Script.Variables()
-  vars.Add('PERL5LIB', ("List of directories in which to look for Perl"
-                         + " library files before looking in the standard"
-                         + " library and the current directory."))
+  vars.Add('PERL5LIB', """
+List of directories in which to look for Perl library files before
+looking in the standard library and the current directory.  It is
+akin to the environment variable of the same name.
+""")
   vars.Update(env)
   SCons.Script.Help(vars.GenerateHelpText(env))
 

--- a/perl5/__init__.py
+++ b/perl5/__init__.py
@@ -61,6 +61,11 @@ def perl5_scanner(node, env, path):
   scan_deps([node])
   return env.File(list(our_deps))
 
+
+def generate_redirect_stdout(source, target, env, for_signature):
+  perl_inc = ["-I" + inc for inc in env['PERL5LIB']]
+  return 'perl5 %s %s > %s' % (" ".join(perl_inc), target[0], source[0])
+
 ## This is currently unused because there's no way to share configure tests.
 def CheckPerlModule(context, module_name):
   context.Message("Checking for perl module %s..." % module_name)
@@ -79,6 +84,9 @@ def generate(env):
 
   scanner = SCons.Script.Scanner(perl5_scanner, skeys=['.pl', '.pm'])
   env.Append(SCANNERS=scanner)
+
+  bld_perl5_output = SCons.Script.Builder(generator=generate_redirect_stdout)
+  env.Append(BUILDERS={'Perl5Output' : bld_perl5_output})
 
 def exists(env):
   if not distutils.spawn.find_executable("perl"):

--- a/perl5/__init__.py
+++ b/perl5/__init__.py
@@ -29,7 +29,7 @@ import SCons.Script
 import SCons.Errors
 
 def get_perl_I(env):
-  return ["-I" + inc for inc in env['PERL5LIB']]
+  return ["-I" + str(inc) for inc in env['PERL5LIB']]
 
 
 ##

--- a/perl5/__init__.py
+++ b/perl5/__init__.py
@@ -78,7 +78,7 @@ def perl5_sub(target, source, env):
 ## PerlOutput
 ##
 
-def create_args_perl5_output(env):
+def create_args_perl5_output(env, source):
   """Create list of arguments for the perl command.
 
   Kinda silly that we need to do this twice, once to generate the
@@ -87,13 +87,18 @@ def create_args_perl5_output(env):
   args = ['perl'] + get_perl_I(env)
   if env.has_key('M'):
     args += ["-M" + m for m in env['M']]
-  args += ["-e", env.get('eval')]
+  if env.has_key('eval'):
+    args += ["-e", env.get('eval')]
+  else:
+    args += [str(source[0])]
+    if env.has_key('args'):
+      args += env.get('args')
   return args
 
 def perl5_output_strfunc(target, source, env):
   """ Create string to be displayed for the builder.
   """
-  args = create_args_perl5_output(env)
+  args = create_args_perl5_output(env, source)
   cmd = "$ %s " % (args[0])
   cmd += " ".join(["'%s'" % (arg) for arg in args[1:]])
   cmd += " > " + str(target[0])
@@ -102,10 +107,11 @@ def perl5_output_strfunc(target, source, env):
 def perl5_output(target, source, env):
   """The actual PerlOutput Builder action.
   """
-  args = create_args_perl5_output(env)
+  args = create_args_perl5_output(env, source)
   with open(str(target[0]), "w") as target_file:
     rv = subprocess.call(args, stdout=target_file)
   return rv
+
 
 
 ##

--- a/perl5/__init__.py
+++ b/perl5/__init__.py
@@ -40,10 +40,13 @@ def perl5_scanner(node, env, path):
   def scan_deps(fpaths):
     my_deps = set()
     for fpath in fpaths:
+      ## note that perl sorts the keys because the order matters (it will
+      ## rebuild the target even if only the order changed), and the order
+      ## of keys in a hash is random.
       code = """
         $deps = scan_deps (files => ['%s'],
                            recurse => 0);
-        foreach (keys %%{$deps})
+        foreach (sort keys %%{$deps})
           { print $deps->{$_}->{file} . "\\n"; }
       """ % str(fpath)
       deps = subprocess.check_output(perl_args + ["-e", code], env=env['ENV'])
@@ -64,7 +67,7 @@ def perl5_scanner(node, env, path):
 
 def generate_redirect_stdout(source, target, env, for_signature):
   perl_inc = ["-I" + inc for inc in env['PERL5LIB']]
-  return 'perl5 %s %s > %s' % (" ".join(perl_inc), target[0], source[0])
+  return 'perl %s -e %s > %s' % (" ".join(perl_inc), env['PERLMETHOD'], target[0])
 
 ## This is currently unused because there's no way to share configure tests.
 def CheckPerlModule(context, module_name):

--- a/perl5/__init__.py
+++ b/perl5/__init__.py
@@ -72,7 +72,7 @@ def perl5_output_strfunc(target, source, env):
 def perl5_output(target, source, env):
   """The actual PerlOutput Builder action.
   """
-  args = create_args_perl5_output_to_target(env)
+  args = create_args_perl5_output(env)
   with open(str(target[0]), "w") as target_file:
     rv = subprocess.call(args, stdout=target_file)
   return rv

--- a/perl5/__init__.py
+++ b/perl5/__init__.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2011-2015 Carnë Draug <carandraug+dev@gmail.com>
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 3 of the
+## License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see
+## <http:##www.gnu.org/licenses/>.
+
+"""SCons tool for perl5 scripts and modules
+"""
+
+import os
+import os.path
+import subprocess
+import distutils.spawn
+
+import SCons.Script
+
+SCANDEPS_BIN = ""
+
+def perl5_scanner(node, env, path):
+  perl_inc = ["-I" + inc for inc in env['PERL5LIB']]
+  perl_args = ["perl", "-MModule::ScanDeps"] + perl_inc
+  code = """
+    $deps = scan_deps (files => ['%s'],
+                       recurse => 0);
+    foreach (keys %%{$deps})
+      { print $deps->{$_}->{file} . "\\n"; }
+  """ % str(node)
+  deps = subprocess.check_output(perl_args + ["-e", code], env=env['ENV'])
+
+  our_deps = []
+  cwd = os.path.realpath(os.getcwd())
+  for dep in deps.splitlines():
+    dep = os.path.realpath(dep)
+    if dep.startswith(cwd):
+      our_deps.append(dep)
+  return env.File(our_deps)
+
+## This is currently unused because there's no way to share configure tests.
+def CheckPerlModule(context, module_name):
+  context.Message("Checking for perl module %s..." % module_name)
+  is_ok = 0 == subprocess.call(["perl", "-M" + module_name, "-e 1"],
+                               stdout = open(os.devnull, "wb"))
+  context.Result(is_ok)
+  return is_ok
+
+def generate(env):
+  vars = SCons.Script.Variables()
+  vars.Add('PERL5LIB', ("List of directories in which to look for Perl"
+                         + " library files before looking in the standard"
+                         + " library and the current directory."))
+  vars.Update(env)
+  SCons.Script.Help(vars.GenerateHelpText(env))
+
+  scanner = SCons.Script.Scanner(perl5_scanner, skeys=['.pl', '.pm'])
+  env.Append(SCANNERS=scanner)
+
+def exists(env):
+  if not distutils.spawn.find_executable("perl"):
+    return 0
+
+  rc = subprocess.call(["perl", "-MModule::ScanDeps", "-e", "1;"])
+  return rc == 0

--- a/perl5/__init__.py
+++ b/perl5/__init__.py
@@ -37,7 +37,9 @@ def get_perl_I(env):
 ##
 
 def create_args_perl5_script(source, env):
-  return ['perl'] + get_perl_I(env) + [str(source[0])] + env['action']
+  return (['perl'] + get_perl_I(env)
+          + [str(source[0])]
+          + [str(a) for a in env['action']])
 
 def perl5_script_strfunc(target, source, env):
   args = create_args_perl5_script(source, env)
@@ -92,7 +94,7 @@ def create_args_perl5_output(env, source):
   else:
     args += [str(source[0])]
     if env.has_key('args'):
-      args += env.get('args')
+      args += [str(a) for a in env.get('args')]
   return args
 
 def perl5_output_strfunc(target, source, env):


### PR DESCRIPTION
This should be the final repo from bitbucket that I save. My aim is to have everything in the scons-contrib repo and then I can change the corresponding references in the ToolsIndex (SCons Wiki), such that they point to scons-contrib instead.
Fixes issue #16 .