### PR TITLE
Fix tools which used Warnings.Warning -> SConsWarning

### DIFF
--- a/sconscontrib/SCons/Tool/IDL/__init__.py
+++ b/sconscontrib/SCons/Tool/IDL/__init__.py
@@ -28,7 +28,7 @@ import SCons.Action
 import SCons.Builder
 
 
-class ToolIDLWarning(SCons.Warnings.Warning):
+class ToolIDLWarning(SCons.Warnings.SConsWarning):
     pass
 
 

--- a/sconscontrib/SCons/Tool/ProC/__init__.py
+++ b/sconscontrib/SCons/Tool/ProC/__init__.py
@@ -26,7 +26,7 @@ import SCons.Action
 import SCons.Builder
 
 
-class ToolProCWarning(SCons.Warnings.Warning):
+class ToolProCWarning(SCons.Warnings.SConsWarning):
     pass
 
 

--- a/sconscontrib/SCons/Tool/gob2/__init__.py
+++ b/sconscontrib/SCons/Tool/gob2/__init__.py
@@ -37,7 +37,7 @@ import SCons.Builder
 import SCons.Util
 
 
-class ToolGob2Warning(SCons.Warnings.Warning):
+class ToolGob2Warning(SCons.Warnings.SConsWarning):
     pass
 
 

--- a/sconscontrib/SCons/Tool/jal/__init__.py
+++ b/sconscontrib/SCons/Tool/jal/__init__.py
@@ -36,7 +36,7 @@ import SCons.Builder
 import SCons.Util
 
 
-class ToolJalWarning(SCons.Warnings.Warning):
+class ToolJalWarning(SCons.Warnings.SConsWarning):
     pass
 
 

--- a/sconscontrib/SCons/Tool/kotlin/__init__.py
+++ b/sconscontrib/SCons/Tool/kotlin/__init__.py
@@ -31,7 +31,7 @@ import SCons.Builder
 import SCons.Util
 
 
-class ToolKotlinWarning(SCons.Warnings.Warning):
+class ToolKotlinWarning(SCons.Warnings.SConsWarning):
     pass
 
 

--- a/sconscontrib/SCons/Tool/noweb/__init__.py
+++ b/sconscontrib/SCons/Tool/noweb/__init__.py
@@ -32,7 +32,7 @@ import SCons.Builder
 import SCons.Util
 
 
-class ToolNowebWarning(SCons.Warnings.Warning):
+class ToolNowebWarning(SCons.Warnings.SConsWarning):
     pass
 
 

--- a/sconscontrib/SCons/Tool/rest/__init__.py
+++ b/sconscontrib/SCons/Tool/rest/__init__.py
@@ -78,7 +78,7 @@ def rst2something(target, source, env, validOptions, writer):
 #
 # Warnings
 #
-class ToolReSTWarning(SCons.Warnings.Warning):
+class ToolReSTWarning(SCons.Warnings.SConsWarning):
     pass
 
 

--- a/sconscontrib/SCons/Tool/sphinx4scons/__init__.py
+++ b/sconscontrib/SCons/Tool/sphinx4scons/__init__.py
@@ -55,7 +55,7 @@ from sphinx.util.matching import patfilter, compile_matchers
 from sphinx.util.osutil import make_filename
 
 
-class ToolSphinxWarning(SCons.Warnings.Warning):
+class ToolSphinxWarning(SCons.Warnings.SConsWarning):
     pass
 
 


### PR DESCRIPTION
This addresses part of #39, but does not completely close it.

Signed-off-by: Mats Wichmann <mats@linux.com>