### PR TITLE
Clean up Protoc README

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
 [build-system]
 requires = ["setuptools>=42","wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+quiet = true
+target-version = ['py36']
+skip-string-normalization = true
+
+[mypy]
+python_version = 3.6

--- a/sconscontrib/SCons/Tool/Protoc/README.md
+++ b/sconscontrib/SCons/Tool/Protoc/README.md
@@ -1,38 +1,33 @@
-##################
-The SCons Protoc tool
-##################
+# The SCons Protoc tool
 
 Scons tool for compiling Google's Protobuf
 
-Basics
-============
+## Basics
 
-Put the ```protoc.py``` file in ```#site_scons/site_tools/``` then in 
+Put the `protoc.py` file in `#site_scons/site_tools/` then in
 your SConstruct file do something like:
 
 ```python
-
 env = Environment(
-  tools = ['default', 'protoc'],
-  #...
-  )
+    tools=["default", "protoc"],
+    ...
+)
 
-env.Replace(PROTOC_CCOUT='/path/to/desired/cpp/output')
+env.Replace(PROTOC_CCOUT="/path/to/desired/cpp/output")
 
 protoc_out = env.Protoc(["src/Example.proto"])
-
 ```
 
 To enable the generation of a language output files you have to supply its
-output directory (```PROTOC_CCOUT```, ```PROTOC_PYOUT```, ```PROTOC_JAVAOUT```).
+output directory (`PROTOC_CCOUT`, `PROTOC_PYOUT`, `PROTOC_JAVAOUT`).
 If you need also to generate the GRPC files, you have to supply the plug-ins
-paths (```PROTOC_GRPC_CC```, ```PROTOC_GRPC_PY```, ```PROTOC_GRPC_JAVA```)
+paths (`PROTOC_GRPC_CC`, `PROTOC_GRPC_PY`, `PROTOC_GRPC_JAVA`)
 
 During the setup of the environment, the protoc compiler will be detected from
-the environment or from the ```PROTOC``` variable.
+the environment or from the `PROTOC` variable.
 
-You can supply some or all of these variables during the creation of the scons
-environment,
+You can supply some or all of these variables using keyword arguments
+during the creation of the construction environment:
 
 ```python
 env = Environment(
@@ -42,52 +37,58 @@ env = Environment(
   PROTOC_GRPC_PY = 'path/to/protoc/grpc_py_plugin',
   PROTOC_GRPC_JAVA = 'path/to/protoc/grpc_java_plugin',
   ...
-  )
-
+)
 ```
 
-or
+or equivalently, using the tool-as-a-tuple form during creation:
 
 ```python
 env = Environment(
-  tools=['default',
-         ('protoc', {PROTOC='path/to/protoc',
-                     PROTOC_GRPC_CC = 'path/to/protoc/grpc_cc_plugin',
-                     PROTOC_GRPC_PY = 'path/to/protoc/grpc_py_plugin',
-                     PROTOC_GRPC_JAVA = 'path/to/protoc/grpc_java_plugin'})],
-  ...
-  )
-
+    tools=[
+        "default",
+        (
+            "protoc",
+            {
+                PROTOC: "path/to/protoc",
+                PROTOC_GRPC_CC: "path/to/protoc/grpc_cc_plugin",
+                PROTOC_GRPC_PY: "path/to/protoc/grpc_py_plugin",
+                PROTOC_GRPC_JAVA: "path/to/protoc/grpc_java_plugin",
+            },
+        ),
+    ]
+    ...
+)
 ```
 
-or using replace after the environment creation
+or using `Replace` after the environment is created:
 
 ```python
-env.Replace(PROTOC='path/to/protoc',
-            PROTOC_GRPC_CC = 'path/to/protoc/grpc_cc_plugin',
-            PROTOC_GRPC_PY = 'path/to/protoc/grpc_py_plugin',
-            PROTOC_GRPC_JAVA = 'path/to/protoc/grpc_java_plugin')
-
+env.Replace(
+    PROTOC="path/to/protoc",
+    PROTOC_GRPC_CC="path/to/protoc/grpc_cc_plugin",
+    PROTOC_GRPC_PY="path/to/protoc/grpc_py_plugin",
+    PROTOC_GRPC_JAVA="path/to/protoc/grpc_java_plugin",
+)
 ```
 
-Your call to the ```Protoc``` builder can still override the variables 
-controlling the build in the call itself.
+Your call to the `Protoc` builder can still override the variables
+controlling the build in the call itself:
 
 ```python
-protoc_out = env.Protoc(["src/Example.proto"],
-                       PROTOC_CCOUT='/path/to/desired/cpp/output',
-                       PROTOC_PYOUT='/path/to/desired/python/output',
-                       PROTOC_JAVAOUT='/path/to/desired/java/output',
-                      )
-
+protoc_out = env.Protoc(
+    ["src/Example.proto"],
+    PROTOC_CCOUT="/path/to/desired/cpp/output",
+    PROTOC_PYOUT="/path/to/desired/python/output",
+    PROTOC_JAVAOUT="/path/to/desired/java/output",
+)
 ```
 
-The path that the ```proto``` file exists in will be added automatically to
-the list of ```proto``` paths. You can add more paths by using the
-```PROTOC_PATH``` variable.
+The path that the `proto` file exists in will be added automatically to
+the list of `proto` paths. You can add more paths by using the
+`PROTOC_PATH` variable.
 
-You can also prepend flags to the ```protoc``` command using the
-```PROTOC_FLAGS``` variable.
+You can also prepend flags to the `protoc` command using the
+`PROTOC_FLAGS` variable.
 
-There are also a set of variables for the different output suffixes and 
+There are also a set of variables for the different output suffixes and
 usually you don't have to touch any of them.


### PR DESCRIPTION
Fix one example that was syntactically incorrect.
Reformat examples in Black style (add section to pyproject.toml for Black)
Twiddle comments a bit.

Signed-off-by: Mats Wichmann <mats@linux.com>