### PR TITLE
Bugfix: Convert <bytes> object to <string>.

### DIFF
--- a/sconscontrib/SCons/Tool/doxygen/doxygen.py
+++ b/sconscontrib/SCons/Tool/doxygen/doxygen.py
@@ -57,7 +57,7 @@ def DoxyfileParse(file_contents, conf_dir, data=None):
 
     import shlex
 
-    lex = shlex.shlex(instream=file_contents, posix=True)
+    lex = shlex.shlex(instream=file_contents.decode("utf-8"), posix=True)
     lex.wordchars += "*+./-:@"
     lex.whitespace = lex.whitespace.replace("\n", "")
     lex.escape = ""

--- a/sconscontrib/SCons/Tool/doxygen/doxygen.py
+++ b/sconscontrib/SCons/Tool/doxygen/doxygen.py
@@ -107,9 +107,8 @@ def DoxyfileParse(file_contents, conf_dir, data=None):
                 if nextfile in data[key]:
                     raise Exception("recursive @INCLUDE in Doxygen config: " + nextfile)
                 data[key].append(nextfile)
-                fh = open(nextfile, "r")
-                DoxyfileParse(fh.read(), conf_dir, data)
-                fh.close()
+                with open(nextfile, "r") as fh:
+                    DoxyfileParse(fh.read(), conf_dir, data)
             else:
                 append_data(data, key, new_data, token)
                 new_data = True

--- a/sconscontrib/SCons/Tool/doxygen/doxygen.py
+++ b/sconscontrib/SCons/Tool/doxygen/doxygen.py
@@ -57,7 +57,7 @@ def DoxyfileParse(file_contents, conf_dir, data=None):
 
     import shlex
 
-    lex = shlex.shlex(instream=file_contents.decode("utf-8"), posix=True)
+    lex = shlex.shlex(instream=file_contents, posix=True)
     lex.wordchars += "*+./-:@"
     lex.whitespace = lex.whitespace.replace("\n", "")
     lex.escape = ""
@@ -181,7 +181,7 @@ def DoxySourceFiles(node, env):
     # go onto the sources list
     conf_dir = os.path.dirname(str(node))
 
-    data = DoxyfileParse(node.get_contents(), conf_dir)
+    data = DoxyfileParse(node.get_text_contents(), conf_dir)
 
     if data.get("RECURSIVE", "NO") == "YES":
         recursive = True
@@ -291,7 +291,8 @@ def DoxyEmitter(target, source, env):
     """Doxygen Doxyfile emitter"""
     doxy_fpath = str(source[0])
     conf_dir = os.path.dirname(doxy_fpath)
-    data = DoxyfileParse(source[0].get_contents(), conf_dir)
+
+    data = DoxyfileParse(source[0].get_text_contents(), conf_dir)
 
     targets = []
     out_dir = data.get("OUTPUT_DIRECTORY", ".")


### PR DESCRIPTION
In DoxyfileParse(), the 'file_contents' parameter is a <bytes> object.
Since the shlex.shlex() member doesn't accept <bytes> objects, we
convert it to a <str>.