### PR TITLE
Improve version skew error reporting for Pandoc tool

### DIFF
--- a/sconscontrib/SCons/Tool/pandoc/__init__.py
+++ b/sconscontrib/SCons/Tool/pandoc/__init__.py
@@ -529,9 +529,12 @@ def exists(env):
             f"Could not parse panflute version {panflute_version_}"
         )
 
-    if any(pandoc_version < (2, 10) and panflute_version >= (2,),
-           pandoc_version > (2, 10) and panflute_version < (2,)):
-        raise SCons.Errors.StopError(
+    import panflute
+    try:
+        panflute.convert_text("test")
+    except TypeError as err:
+        if re.search("invalid api version", str(err)):
+            raise SCons.Errors.StopError(
                 PanflutePandocVersionSkew,
                 f"Incompatible Pandoc (version {pandoc_version_}) and "
                 f"Panflute (version {panflute_version_}) found"

--- a/sconscontrib/SCons/Tool/pandoc/__init__.py
+++ b/sconscontrib/SCons/Tool/pandoc/__init__.py
@@ -468,7 +468,7 @@ _builder = SCons.Builder.Builder(
 def generate(env):
     """Add the Builders and construction variables to the Environment
     """
-    env["PANDOC"] = _detect(env)
+    env["PANDOC"] = exists(env)
     command = "$PANDOC $PANDOCFLAGS -o ${TARGET} ${SOURCES}"
     env.SetDefault(
             # Command line flags.


### PR DESCRIPTION
The Pandoc Tool relies on the third party package [panflute](https://pypi.org/project/panflute/) to load and walk the document tree. However, panflute requires a compatible version of Pandoc based on its version. The previous code did not reliably check for the version skew for two reasons. First, the `exists` function was not called (per the note under [Tool Modules](https://scons.org/doc/production/HTML/scons-man.html#tool_modules)), and second, the version check was tied to version incompatibilities known at the time. This would lead to obscure errors being reported while scanning for dependencies

This PR updates the Pandoc tool to check for valid external tools when calling generate, and improves the version skew check to be more stable with a better error message.