### PR TITLE
Add tool to use Inkscape to convert SVG files

### DIFF
--- a/sconscontrib/SCons/Tool/inkscape/README.rst
+++ b/sconscontrib/SCons/Tool/inkscape/README.rst
@@ -1,0 +1,112 @@
+SCons tool for using Inkscape to convert images
+===============================================
+
+A common occurrence when writing is needing to convert an image format
+to include in your document.  You will spend valuable (and important)
+time adjusting your plot with ``pgfplots`` for LaTeX only to discover
+that the journal expects a Word document.  Alternatively, you realize
+that you want to use an particular vector graphic from a journal article
+you submitted in a conference presentation requiring PowerPoint.  One
+way to handle these situations is to simply regenerate the image in an
+appropriate format.  However, that is a very manual and time consuming
+process and does not sound like fun.  If your image is a high quality
+SVG hand crafted in a drawing tool, you could easily reduce the quality
+of the image by exporting the wrong format or lose your high quality
+professional fonts.
+
+You, on the other hand, are enlightened enough to use a `build tool`_ to
+automate away most of this tediousness (otherwise you would not be
+here).  This is a :class:`SCons.Tool` for teaching SCons_ how to use
+Inkscape_ to convert vector images between formats.  The native format
+of Inkscape is SVG, but it is also able to easily export PDF, PDF plus
+the boiler plate LaTeX for directly including in a LaTeX document, or
+even an PNG for inclusion into Word or PowerPoint document.  (The
+inclusion of the last two formats is to facilitate working with Pandoc_
+and the `associated tool`_)
+
+.. _SCons: https://scons.org
+.. _build tool: SCons_
+.. _Inkscape: https://inkscape.org
+.. _Pandoc: https://pandoc.org
+.. _associated tool: https://github.com/SCons/scons-contrib/tree/master/sconscontrib/SCons/Tool/pandoc
+
+Installation
+------------
+
+The tool follows the convention described in the ToolsIndex_.  Simply
+clone this repository into your ``site_scons/site_tools`` directory
+under the name ``inkscape``.  Then add::
+
+   env = Environment(tools=["inkscape"])
+
+to your ``SConstruct`` and you are ready to go.  Alternatively, you
+could just copy the ``__init__.py`` to your tools directory, but why
+would you want to do that?
+
+.. _ToolsIndex: https://github.com/SCons/scons/wiki/ToolsIndex
+
+Usage
+-----
+
+This tool provides the ``Inkscape`` builder.  The simplest usage is
+
+.. code-block:: python
+
+    png = env.Inkscape("img.png", "img.svg")
+
+If you wish to pass additional flags to the Inkscape invocation, you can
+set the ``INKSCAPEFLAGS`` variable.  For example, to generate a PDF and
+export all text to LaTeX you can use
+
+.. code-block:: python
+
+    pdf = env.Inkscape("img.pdf", "img.svg", INKSCAPEFLAGS="--export-latex")
+
+.. note:: A prior version (0.0.1_) created convenience Builders for
+   common conversions.  However, with Inkscape 1.0.0, these became
+   reduentant since Inkscape can now handle these details directly.
+
+License
+-------
+
+This is Open Source software under the MIT license. For full details,
+see the license statement in the ``__init__.py``.
+
+Changelog
+---------
+
+All notable changes to this project will be documented in this section.
+The format is based on `Keep a Changelog`_.
+
+Unreleased_
+^^^^^^^^^^^
+
+Fixed
+'''''
+
+-   Corrected LaTeX annotation in docstring
+
+0.1.0_ 2021-08-08
+^^^^^^^^^^^^^^^^^
+
+Changed
+'''''''
+
+-   Migrated development to ``trunk``
+-   Updated to Inkscape 1+ argument syntax
+-   Updated to the SCons preferred syntax of the MIT License
+
+Removed
+'''''''
+
+-   Extension specific Builders
+
+0.0.1_ 2021-08-07
+^^^^^^^^^^^^^^^^^
+
+-   Initial release that “worked” with Inkscape 0.92
+
+.. _Unreleased: https://github.com/kprussing/scons-inkscape/compare/v0.1.0...HEAD
+.. _0.1.0: https://github.com/kprussing/scons-inkscape/compare/v0.0.1..v0.1.0
+.. _0.0.1: https://github.com/kprussing/scons-inkscape/releases/tag/v0.0.1
+.. _Keep a Changelog: https://keepachangelog.com/en/1.0.0/

--- a/sconscontrib/SCons/Tool/inkscape/__init__.py
+++ b/sconscontrib/SCons/Tool/inkscape/__init__.py
@@ -21,7 +21,7 @@
 # CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-__doc__="""SCons.Tool.Inkscape
+"""SCons.Tool.Inkscape
 
 Builders for converting vector graphics using Inkscape.  Specifically,
 converting SVG to PDF, PDF + ``LaTeX``, and PNG and PDF to PNG.

--- a/sconscontrib/SCons/Tool/inkscape/__init__.py
+++ b/sconscontrib/SCons/Tool/inkscape/__init__.py
@@ -1,6 +1,7 @@
 # MIT License
 #
-# Copyright 2016-2021 Keith F Prussing
+# Copyright 2024 The SCons Foundation
+# Copyright 2016-2024 Keith F Prussing
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/sconscontrib/SCons/Tool/inkscape/__init__.py
+++ b/sconscontrib/SCons/Tool/inkscape/__init__.py
@@ -1,0 +1,163 @@
+# MIT License
+#
+# Copyright 2016-2021 Keith F Prussing
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+__doc__="""SCons.Tool.Inkscape
+
+Builders for converting vector graphics using Inkscape.  Specifically,
+converting SVG to PDF, PDF + ``LaTeX``, and PNG and PDF to PNG.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Tool.Tool() selection
+method.
+
+"""
+
+#
+# Acknowledgements
+# ----------------
+#
+# The format of this Tool is highly influenced by the JAL Tool on the
+# ToolsForFools_ page from the SCons Wiki.
+#
+# .. ToolsForFools: https://github.com/SCons/scons/wiki/ToolsForFools
+#
+
+import SCons.Action
+import SCons.Builder
+import SCons.Errors
+try:
+    from SCons.Warnings import SConsWarning as SConsWarning
+except ImportError:
+    from SCons.Warnings import Warning as SConsWarning
+
+import itertools
+import os
+import pathlib
+import platform
+import re
+
+#
+# Preliminary details
+# ~~~~~~~~~~~~~~~~~~~
+#
+# Begin by defining local errors
+
+class ToolInkscapeWarning(SConsWarning):
+    pass
+
+class InkscapeNotFound(ToolInkscapeWarning):
+    pass
+
+SCons.Warnings.enableWarningClass(ToolInkscapeWarning)
+
+#
+# Utility functions
+# ~~~~~~~~~~~~~~~~~
+#
+def _detect(env):
+    """Try to locate the Inkscape executable
+    """
+    try:
+        # Check if we've already found it
+        return env["INKSCAPE"]
+    except KeyError:
+        pass
+
+    # Next try searching the Path.  This should work on *nix and nicely
+    # configured Windows systems.
+    inkscape = env.WhereIs("inkscape")
+    if inkscape:
+        return inkscape
+
+    # That didn't work so Inkscape must not be on the PATH.  As a last
+    # resort, we can try to scan "known" installation locations on
+    # Windows and Darwin to see if we can locate the binary.
+    if platform.system() == "Windows":
+        # This assumes proper binary compatibility and considers the
+        # user may be running under CygWin.
+        prog = os.path.join("PROGRA~1", "Inkscape", "inkscape.com")
+        for root in ("C:" + os.sep, os.path.join("/cygdrive", "c")):
+            inkscape = env.WhereIs(os.path.join(root, prog))
+            if inkscape:
+                return inkscape
+
+    elif platform.system() == "Darwin":
+        # macOS could have been installed using their installer.
+        inkscape = env.WhereIs(os.path.join("/Applications",
+                                            "Inkscape.app",
+                                            "Contents",
+                                            "MacOS",
+                                            "inkscape")
+                               )
+        if inkscape:
+            return inkscape
+
+    # And the last ditch failed.  Time to just error out
+    raise SCons.Errors.StopError(InkscapeNotFound,
+                                 "Could not find Inkscape executable")
+
+
+#
+# Emitters
+# ~~~~~~~~
+#
+def _emitter(target, source, env):
+    """Define a generic emitter for the LaTeX exporting"""
+    if re.search("--export-latex", env.get("INKSCAPEFLAGS", "")):
+        target.extend(
+            [str(_) + "_tex" for _ in target
+             if pathlib.Path(str(_)).suffix in (".pdf", ".ps", ".eps")
+             ]
+        )
+
+    return target, source
+
+#
+# Builders
+# ~~~~~~~~
+#
+
+_builder = SCons.Builder.Builder(
+    action=SCons.Action.Action("$INKSCAPECOM", "$INKSCAPECOMSTR"),
+    emitter=_emitter
+)
+
+#
+# SCons functions
+# ~~~~~~~~~~~~~~~
+#
+
+def generate(env):
+    """Add the builder to the :class:`SCons.Environment.Environment`
+    """
+    env["INKSCAPE"] = _detect(env)
+
+    env.SetDefault(
+        INKSCAPECOM="$INKSCAPE $INKSCAPEFLAGS --export-filename=$TARGET $SOURCE",
+        INKSCAPEFLAGS="",
+        INKSCAPECOMSTR="",
+    )
+    env["BUILDERS"]["Inkscape"] = _builder
+
+
+def exists(env):
+    return _detect(env)

--- a/sconscontrib/SCons/Tool/inkscape/example/SConstruct
+++ b/sconscontrib/SCons/Tool/inkscape/example/SConstruct
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+#
+# To run the example, place .. in a place SCons will be able to locate
+# via the standard Tool loading.  One possibility would be:
+#
+#    mkdir -p site_scons/site_tools/
+#    cd site_scons/site_tools
+#    ln -s ../../../__init__.py inkscape.py.
+
+import os
+
+env = Environment(ENV=os.environ, tools=["inkscape"])
+
+src = "example"
+
+png = env.Inkscape(src + "-1.png", src + ".svg")
+pdf = env.Inkscape(src + ".pdf", src + ".svg")
+wmf = env.Inkscape(src + ".wmf", src + ".svg")
+pdf_tex = env.Inkscape(src + "-2.pdf", src + ".svg",
+                       INKSCAPEFLAGS="--export-latex")
+
+png2 = env.Inkscape(src + "-2.svg", pdf)

--- a/sconscontrib/SCons/Tool/inkscape/example/example.svg
+++ b/sconscontrib/SCons/Tool/inkscape/example/example.svg
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- CC0 -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="86mm"
+   height="43mm"
+   viewBox="0 0 304.72441 152.3622"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="example.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker4994"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Send">
+      <path
+         transform="scale(0.2) rotate(180) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path4996" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker4498"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Send">
+      <path
+         transform="scale(0.2) rotate(180) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path4500" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Send"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Send"
+       style="overflow:visible;"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4195"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.2) rotate(180) translate(6,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Mend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path4189"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.4) rotate(180) translate(10,0)" />
+    </marker>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="9.2470545 : 93.065039 : 1"
+       inkscape:vp_y="0 : 1319.9129 : 0"
+       inkscape:vp_z="367.11936 : 93.065039 : 1"
+       inkscape:persp3d-origin="188.18319 : 59.547567 : 1"
+       id="perspective4172" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-39.215145 : 73.239596 : 1"
+       inkscape:vp_y="0 : 1319.9129 : 0"
+       inkscape:vp_z="318.65718 : 73.239596 : 1"
+       inkscape:persp3d-origin="139.72101 : 39.722124 : 1"
+       id="perspective4142" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.7237726"
+     inkscape:cx="155.48288"
+     inkscape:cy="76.897325"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1280"
+     inkscape:window-height="657"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-900)">
+    <g
+       sodipodi:type="inkscape:box3d"
+       id="g4144"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0"
+       inkscape:perspectiveID="#perspective4142"
+       inkscape:corner0="1.8040539 : -0.083215828 : 0 : 1"
+       inkscape:corner7="1.2022277 : -0.083327722 : 0.23484646 : 1">
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4154"
+         style="fill:#afafde;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="13"
+         d="m 24.598233,1030.2995 17.438961,13.9857 26.656234,-6.2794 -21.370297,-11.6612 z"
+         points="42.037194,1044.2852 68.693428,1038.0058 47.323131,1026.3446 24.598233,1030.2995 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4146"
+         style="fill:#353564;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="6"
+         d="m 24.598233,1030.2468 0,0.053 22.724898,-3.9549 0,-0.049 z"
+         points="24.598233,1030.2995 47.323131,1026.3446 47.323131,1026.296 24.598233,1030.2468 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4156"
+         style="fill:#e9e9ff;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="11"
+         d="m 47.323131,1026.296 21.370297,11.6492 0,0.061 -21.370297,-11.6612 z"
+         points="68.693428,1037.9452 68.693428,1038.0058 47.323131,1026.3446 47.323131,1026.296 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4148"
+         style="fill:#4d4d9f;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="5"
+         d="m 24.598233,1030.2468 17.438961,13.9713 26.656234,-6.2729 -21.370297,-11.6492 z"
+         points="42.037194,1044.2181 68.693428,1037.9452 47.323131,1026.296 24.598233,1030.2468 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4152"
+         style="fill:#d7d7ff;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="14"
+         d="m 42.037194,1044.2181 0,0.067 26.656234,-6.2794 0,-0.061 z"
+         points="42.037194,1044.2852 68.693428,1038.0058 68.693428,1037.9452 42.037194,1044.2181 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4150"
+         style="fill:#8686bf;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="3"
+         d="m 24.598233,1030.2468 17.438961,13.9713 0,0.067 -17.438961,-13.9857 z"
+         points="42.037194,1044.2181 42.037194,1044.2852 24.598233,1030.2995 24.598233,1030.2468 " />
+    </g>
+    <g
+       sodipodi:type="inkscape:box3d"
+       id="g4158"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0"
+       inkscape:perspectiveID="#perspective4172"
+       inkscape:corner0="-0.18879707 : 0.050886785 : 0 : 1"
+       inkscape:corner7="-0.2820095 : 0.034276988 : 0.0075929209 : 1">
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4170"
+         style="fill:#e9e9ff;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="11"
+         d="m 231.10141,918.20187 28.50062,-5.27932 0,30.21497 -28.50062,1.83963 z"
+         points="259.60203,912.92255 259.60203,943.13752 231.10141,944.97715 231.10141,918.20187 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4160"
+         style="fill:#353564;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="6"
+         d="m 229.82827,917.81722 0,27.02589 1.27314,0.13404 0,-26.77528 z"
+         points="229.82827,944.84311 231.10141,944.97715 231.10141,918.20187 229.82827,917.81722 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4162"
+         style="fill:#4d4d9f;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="5"
+         d="m 229.82827,917.81722 28.63674,-5.3851 1.13702,0.49043 -28.50062,5.27932 z"
+         points="258.46501,912.43212 259.60203,912.92255 231.10141,918.20187 229.82827,917.81722 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4168"
+         style="fill:#afafde;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="13"
+         d="m 229.82827,944.84311 28.63674,-1.87648 1.13702,0.17089 -28.50062,1.83963 z"
+         points="258.46501,942.96663 259.60203,943.13752 231.10141,944.97715 229.82827,944.84311 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4166"
+         style="fill:#d7d7ff;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="14"
+         d="m 258.46501,912.43212 0,30.53451 1.13702,0.17089 0,-30.21497 z"
+         points="258.46501,942.96663 259.60203,943.13752 259.60203,912.92255 258.46501,912.43212 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path4164"
+         style="fill:#8686bf;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         inkscape:box3dsidetype="3"
+         d="m 229.82827,917.81722 28.63674,-5.3851 0,30.53451 -28.63674,1.87648 z"
+         points="258.46501,912.43212 258.46501,942.96663 229.82827,944.84311 229.82827,917.81722 " />
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;marker-end:url(#Arrow1Send)"
+       d="m 243.77953,931.20671 -37.8152,0"
+       id="path4174"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;baseline-shift:baseline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="204.86292"
+       y="922.02826"
+       id="text4482"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4484"
+         x="204.86292"
+         y="922.02826">d<tspan
+   style="font-weight:bold"
+   id="tspan4976">A</tspan><tspan
+   style="font-size:64.99999762%;baseline-shift:sub"
+   id="tspan4984">i</tspan></tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4496"
+       d="m 45.35058,1035.2812 0,-27.9461"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4498)" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4958"
+       y="1020.0541"
+       x="20.926851"
+       style="font-style:normal;font-weight:normal;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;baseline-shift:baseline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         y="1020.0541"
+         x="20.926851"
+         id="tspan4960"
+         sodipodi:role="line">d<tspan
+   style="font-weight:bold"
+   id="tspan4972">A</tspan><tspan
+   style="font-size:64.99999762%;baseline-shift:sub"
+   id="tspan4968">j</tspan></tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4994)"
+       d="M 46.259368,1035.1067 239.74101,933.77667"
+       id="path4986"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="154.93216"
+       y="992.51874"
+       id="text5100"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan5102"
+         x="154.93216"
+         y="992.51874"
+         style="font-weight:bold;font-size:12.5px">r<tspan
+   style="font-weight:normal;font-size:64.99999762%;baseline-shift:sub"
+   id="tspan5104">ij</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="15.786927"
+       y="929.00391"
+       id="text5106"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan5108"
+         x="15.786927"
+         y="929.00391"
+         style="font-size:12.5px">Text with the the</tspan><tspan
+         sodipodi:role="line"
+         x="15.786927"
+         y="944.62891"
+         style="font-size:12.5px"
+         id="tspan5110">correct size font. </tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
Issue [2373](https://github.com/SCons/scons/issues/2373) in the main SCons repository copied a request to for a tool to convert SVG files to PDF format.  The [linked bugreport](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=508688) shows the desire to use Inkscape for the job. This is a tool I hacked together to support conversion of SVG files to PDF, PDF + LaTeX, and PNG using Inkscape.

The tool relies on hard coded paths to Inkscape on Windows and macOS (if the executable is not default found). This could break if the installation directory on either platform changes.