### PR TITLE
Add spinner tool: compact build output

### DIFF
--- a/sconscontrib/SCons/Tool/spinner/README.rst
+++ b/sconscontrib/SCons/Tool/spinner/README.rst
@@ -1,0 +1,257 @@
+Spinner: compact build output for SCons
+========================================
+
+The **spinner** tool replaces SCons' default verbose build output (which
+prints the full shell command for every build step) with compact,
+single-line status messages that overwrite each other in place.
+
+Instead of::
+
+    gcc -o build/src/drivers/uart.o -c -I/path/to/include -Wall -Werror -O2 src/drivers/uart.c
+
+you see::
+
+    Compiling src/drivers/uart.c
+
+which is overwritten in-place as each build step completes. The effect
+is a quiet, focused build display similar to CMake's or Ninja's default
+output.
+
+When stdout is not a TTY (such as in CI environments or when piped to a
+file), the tool falls back to printing one line per build step without
+ANSI escape sequences.
+
+Installation
+------------
+
+Install the ``scons-contrib`` package::
+
+    pip install git+https://github.com/SCons/scons-contrib.git
+
+Or manually copy the ``spinner`` directory into your project's
+``site_scons/site_tools/`` directory.
+
+Usage
+-----
+
+Activate the tool when creating your construction environment::
+
+    env = Environment(tools=['default', 'spinner'])
+
+That's it. All standard builders (C/C++, Fortran, Lex, Yacc, Java,
+linker, archiver, and install) will display spinner output.
+
+Verbose mode
+~~~~~~~~~~~~
+
+SCons does not have a built-in ``--verbose`` option, and SCons tools
+cannot define command-line options (only ``SConstruct`` files can).
+To let users disable the spinner and see full build commands, define
+your own option in your ``SConstruct`` and pass it to the spinner
+via ``SPINNER_DISABLE``::
+
+    AddOption('--verbose',
+              dest='verbose',
+              action='store_true',
+              default=False,
+              help='Show full build commands')
+
+    env = Environment(
+        tools=['default', 'spinner'],
+        SPINNER_DISABLE=GetOption('verbose'),
+    )
+
+When ``SPINNER_DISABLE`` is truthy, the spinner leaves
+``PRINT_CMD_LINE_FUNC`` and all ``*COMSTR`` variables at their
+defaults, so SCons prints the full shell commands as usual.
+``SpinnerAction`` is still available but returns a plain ``Action``
+without the spinner display override, so custom builders also
+fall back to showing raw commands.
+
+If your project already has a verbosity flag under a different name,
+simply wire it to ``SPINNER_DISABLE`` the same way::
+
+    env = Environment(
+        tools=['default', 'spinner'],
+        SPINNER_DISABLE=my_build_options.verbose,
+    )
+
+Multi-platform prefix
+~~~~~~~~~~~~~~~~~~~~~
+
+If you are building for multiple platforms and want to distinguish
+them in the output, set ``SPINNER_PREFIX``::
+
+    arm_env = env.Clone()
+    arm_env['SPINNER_PREFIX'] = 'arm'
+    x86_env = env.Clone()
+    x86_env['SPINNER_PREFIX'] = 'x86'
+
+This produces output like::
+
+    [arm] Compiling src/drivers/uart.c
+
+Custom builders
+~~~~~~~~~~~~~~~
+
+To add spinner output to custom builders or commands, use
+``SpinnerAction`` to create an ``Action`` with the spinner display
+string wired in.
+
+With a ``Builder``::
+
+    env.Append(BUILDERS = {
+        "HexFile": Builder(
+            src_suffix = ".elf",
+            suffix = ".hex",
+            action = env.SpinnerAction(
+                "objcopy $SOURCE -O ihex $TARGET",
+                'Creating hex',
+                use_source=False,
+            ),
+        ),
+    })
+
+With ``env.Command``::
+
+    env.Command(
+        target = 'output.ch',
+        source = 'input.txt',
+        action = env.SpinnerAction(
+            'my_converter.py $SOURCE > $TARGET',
+            'Generating',
+            use_source=False,
+        ),
+    )
+
+The ``use_source`` parameter controls whether the source filename or
+the target filename is displayed. Use ``True`` (the default) for
+compile-like builders and ``False`` for link/archive builders that
+produce one target from many sources.
+
+Environment variable overrides
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``PRETEND_ISATTY``
+    Set to a truthy value (e.g. ``1``, ``true``, ``yes``) in the OS
+    environment to force ANSI spinner output even when stdout is not
+    a TTY. Useful for testing. Values of ``0``, ``false``, ``no``,
+    and empty/unset are treated as false.
+
+Construction variables
+----------------------
+
+``SPINNER_DISABLE``
+    If set to a truthy value, the spinner is not installed and SCons'
+    default verbose output is preserved. ``SpinnerAction`` remains
+    available but returns plain ``Action`` objects without spinner
+    display overrides.
+
+``SPINNER_PREFIX``
+    Optional string displayed in brackets before each action name.
+    Set per-environment to distinguish builds for different platforms.
+
+``PRINT_CMD_LINE_FUNC``
+    Set by ``generate()`` to the spinner print function. This is a
+    standard SCons construction variable.
+
+Examples
+--------
+
+Minimal usage
+~~~~~~~~~~~~~
+
+::
+
+    # SConstruct
+    env = Environment(tools=['default', 'spinner'])
+    env.Program('hello', 'hello.c')
+
+Output::
+
+    Compiling hello.c
+    Linking hello
+
+With verbose flag and multi-platform builds
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    # SConstruct
+    AddOption('--verbose',
+              dest='verbose',
+              action='store_true',
+              default=False,
+              help='Show full build commands')
+
+    env = Environment(
+        tools=['default', 'spinner'],
+        SPINNER_DISABLE=GetOption('verbose'),
+    )
+
+    # Build for two platforms
+    arm_env = env.Clone()
+    arm_env['SPINNER_PREFIX'] = 'arm'
+    arm_env.Object('build/arm/main.o', 'src/main.c')
+
+    x86_env = env.Clone()
+    x86_env['SPINNER_PREFIX'] = 'x86'
+    x86_env.Object('build/x86/main.o', 'src/main.c')
+
+Output with ``scons``::
+
+    [arm] Compiling src/main.c
+    [x86] Compiling src/main.c
+
+Output with ``scons --verbose``::
+
+    arm-gcc -o build/arm/main.o -c -Iinclude src/main.c
+    gcc -o build/x86/main.o -c -Iinclude src/main.c
+
+With custom builders
+~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    # SConstruct
+    env = Environment(tools=['default', 'spinner'])
+
+    env.Append(BUILDERS = {
+        "HexFile": Builder(
+            src_suffix = ".elf",
+            suffix = ".hex",
+            action = env.SpinnerAction(
+                "objcopy $SOURCE -O ihex $TARGET",
+                'Creating hex',
+                use_source=False,
+            ),
+        ),
+    })
+
+    env.HexFile('firmware.hex', 'firmware.elf')
+
+Output::
+
+    Creating hex firmware.hex
+
+How it works
+------------
+
+For standard builders, the tool sets each builder's ``*COMSTR``
+variable to an internal marker string containing the human-readable
+action name. For custom builders, ``SpinnerAction`` embeds the same
+marker as the ``Action``'s display string. In both cases, the tool
+sets ``PRINT_CMD_LINE_FUNC`` to a custom print function that
+recognizes the markers, extracts the action name and the relevant
+filename, makes the path relative to the project root (the directory
+containing the top-level ``SConstruct``), truncates long paths to
+fit the terminal width, and writes the result using ANSI escape
+sequences to overwrite the previous line.
+
+Non-marked strings (such as output from builders that were not
+configured with the spinner) are printed normally.
+
+License
+-------
+
+MIT License. Copyright 2019-2025 Jeremy Elson.

--- a/sconscontrib/SCons/Tool/spinner/__init__.py
+++ b/sconscontrib/SCons/Tool/spinner/__init__.py
@@ -1,0 +1,38 @@
+#  A SCons tool that replaces default build output with a compact,
+#  single-line spinner display.
+#
+#  Copyright 2019-2025 Jeremy Elson
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""SCons.Tool.spinner
+
+A Tool that replaces default SCons build output with a compact,
+single-line spinner display. Instead of printing full shell commands,
+it shows a brief description of each build step (e.g. "Compiling
+src/main.c") that overwrites itself in-place using ANSI escape
+sequences.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+"""
+
+from .spinner import exists, generate

--- a/sconscontrib/SCons/Tool/spinner/spinner.py
+++ b/sconscontrib/SCons/Tool/spinner/spinner.py
@@ -1,0 +1,264 @@
+"""Implementation of the spinner build output tool for SCons.
+
+Replaces verbose build command output with compact, single-line status
+messages that overwrite each other in-place using ANSI escape sequences.
+"""
+
+import os
+import shutil
+import sys
+
+from SCons.Action import Action
+
+
+# Internal marker protocol. These strings are placed into *COMSTR
+# variables and recognized by the print function to trigger spinner
+# behavior.
+_MARKER = '<<spinner>>'
+_SOURCE = 'src'
+_TARGET = 'trg'
+
+
+def spinner_comstr(action_name, use_source=True):
+    """Create a *COMSTR value that triggers the spinner for a builder.
+
+    Args:
+        action_name: Human-readable action name, e.g. "Compiling".
+        use_source: If True, display the source filename (appropriate
+            for compile-like steps). If False, display the target
+            filename (appropriate for link/archive steps that have
+            many sources and one target).
+
+    Returns:
+        A string suitable for assignment to a *COMSTR construction
+        variable, e.g. env['CCCOMSTR'] = spinner_comstr('Compiling')
+    """
+    which = _SOURCE if use_source else _TARGET
+    return _MARKER + which + action_name
+
+
+class SpinnerPrinter:
+    """Replaces default SCons build output with a compact spinner.
+
+    When stdout is a TTY, each build step's output overwrites the
+    previous line using ANSI escape sequences. When stdout is not a
+    TTY (e.g. in CI), output is printed one line per step without
+    ANSI codes.
+    """
+
+    def __init__(self, project_root):
+        """Initialize the SpinnerPrinter.
+
+        Args:
+            project_root: Absolute path to the project root directory.
+                File paths will be displayed relative to this directory.
+        """
+        self._project_root = project_root
+        is_tty = sys.stdout.isatty()
+        pretend = os.environ.get('PRETEND_ISATTY', '').lower() not in ('', '0', 'false', 'no')
+        self._use_ansi = is_tty or pretend
+
+    def __call__(self, s, target, source, env):
+        """Print function compatible with SCons' PRINT_CMD_LINE_FUNC.
+
+        This method has the signature (s, target, source, env) as
+        required by SCons.
+        """
+        # Non-spinner strings pass through unchanged
+        if not s.startswith(_MARKER):
+            sys.stdout.write(s + "\n")
+            return
+
+        # Parse the marker: <<spinner>>{src|trg}{ActionName}
+        rest = s[len(_MARKER):]
+        which = rest[0:3]
+        action_name = rest[3:]
+
+        # Build the prefix: optional [platform] + action name
+        prefix = action_name + ' '
+        spinner_prefix = env.get('SPINNER_PREFIX', '')
+        if spinner_prefix:
+            prefix = f'[{spinner_prefix}] {prefix}'
+
+        # Choose source or target filename to display. Compile-like
+        # steps show the source; link/archive steps show the target.
+        if which == _SOURCE and source:
+            file_node = source[0]
+        elif target:
+            file_node = target[0]
+        else:
+            sys.stdout.write(prefix.rstrip() + "\n")
+            return
+
+        fn_abs = os.path.realpath(str(file_node))
+
+        # Make path relative to the project root
+        fn_display = os.path.relpath(fn_abs, self._project_root)
+
+        # If the file is outside the project tree, show the absolute path
+        if fn_display.startswith('..'):
+            fn_display = fn_abs
+
+        if not self._use_ansi:
+            # Non-TTY: simple one-line output
+            sys.stdout.write(f"{prefix}{fn_display}\n")
+            return
+
+        # TTY: overwrite the previous line
+        terminal_width = shutil.get_terminal_size().columns
+        spaces_avail = terminal_width - len(prefix) - 1
+
+        # Keep truncating pathname parts from the left until the
+        # filename fits on the screen
+        while len(fn_display) > spaces_avail and '/' in fn_display:
+            fn_display = fn_display[fn_display.index('/') + 1:]
+
+        out = f"{prefix}{fn_display}"
+
+        # \x1b[K  = erase to end of line
+        # \n      = newline
+        # \x1b[1A = cursor up one line
+        # Net effect: overwrite this line with the next step's output
+        sys.stdout.write(f"\x1b[K{out}\n\x1b[1A")
+        sys.stdout.flush()
+
+
+
+def _spinner_action(env, cmd, action_name, use_source=True):
+    """Environment method to create an Action with spinner output.
+
+    Use this when defining custom Builders. Returns an Action whose
+    display string is the spinner output instead of the raw command.
+
+    When SPINNER_DISABLE is truthy, returns a plain Action without
+    a display string override, so SCons prints the raw command.
+
+    Usage::
+
+        env.Append(BUILDERS = {
+            "HexFile": Builder(
+                action = env.SpinnerAction(
+                    "objcopy $SOURCE -O ihex $TARGET",
+                    'Creating hex',
+                    use_source=False,
+                ),
+            ),
+        })
+
+    Args:
+        env: SCons construction environment (passed automatically).
+        cmd: The shell command string for the action.
+        action_name: Human-readable name, e.g. 'Creating hex'.
+        use_source: If True, display source filename; if False, target.
+    """
+    if env.get('SPINNER_DISABLE'):
+        return Action(cmd)
+    return Action(cmd, spinner_comstr(action_name, use_source))
+
+
+# Standard builders and their spinner configurations.
+# Each entry is (COMSTR_variable, action_name, use_source).
+_STANDARD_BUILDERS = [
+    # C / C++
+    ('CCCOMSTR',          'Compiling',        True),
+    ('CXXCOMSTR',         'Compiling',        True),
+    ('SHCCCOMSTR',        'Compiling',        True),
+    ('SHCXXCOMSTR',       'Compiling',        True),
+
+    # Assembler
+    ('ASCOMSTR',          'Assembling',       True),
+    ('ASPPCOMSTR',        'Assembling',       True),
+
+    # Fortran
+    ('FORTRANCOMSTR',     'Compiling',        True),
+    ('SHFORTRANCOMSTR',   'Compiling',        True),
+    ('FORTRANPPCOMSTR',   'Compiling',        True),
+    ('SHFORTRANPPCOMSTR', 'Compiling',        True),
+    ('F77COMSTR',         'Compiling',        True),
+    ('SHF77COMSTR',       'Compiling',        True),
+    ('F77PPCOMSTR',       'Compiling',        True),
+    ('SHF77PPCOMSTR',     'Compiling',        True),
+    ('F90COMSTR',         'Compiling',        True),
+    ('SHF90COMSTR',       'Compiling',        True),
+    ('F90PPCOMSTR',       'Compiling',        True),
+    ('SHF90PPCOMSTR',     'Compiling',        True),
+    ('F95COMSTR',         'Compiling',        True),
+    ('SHF95COMSTR',       'Compiling',        True),
+    ('F95PPCOMSTR',       'Compiling',        True),
+    ('SHF95PPCOMSTR',     'Compiling',        True),
+    ('F03COMSTR',         'Compiling',        True),
+    ('SHF03COMSTR',       'Compiling',        True),
+    ('F03PPCOMSTR',       'Compiling',        True),
+    ('SHF03PPCOMSTR',     'Compiling',        True),
+    ('F08COMSTR',         'Compiling',        True),
+    ('SHF08COMSTR',       'Compiling',        True),
+    ('F08PPCOMSTR',       'Compiling',        True),
+    ('SHF08PPCOMSTR',     'Compiling',        True),
+
+    # Lex / Yacc
+    ('LEXCOMSTR',         'Generating lexer', True),
+    ('YACCCOMSTR',        'Generating parser', True),
+
+    # Java
+    ('JAVACCOMSTR',       'Compiling',        True),
+    ('JARCOMSTR',         'Creating JAR',     False),
+    ('RMICCOMSTR',        'Generating RMI stubs', True),
+    ('JAVAHCOMSTR',       'Generating JNI headers', True),
+
+    # Linker
+    ('LINKCOMSTR',        'Linking',          False),
+    ('SHLINKCOMSTR',      'Linking',          False),
+    ('LDMODULECOMSTR',    'Linking',          False),
+
+    # Archive / library
+    ('ARCOMSTR',          'Creating library', False),
+    ('RANLIBCOMSTR',      'Indexing library', False),
+
+    # Install
+    ('INSTALLSTR',        'Installing',       True),
+]
+
+
+def generate(env):
+    """Set up the spinner tool in the given SCons environment.
+
+    Installs a PRINT_CMD_LINE_FUNC that replaces verbose build
+    commands with compact, single-line spinner output. Configures
+    all standard C/C++ builder COMSTR variables.
+
+    If SPINNER_DISABLE is set to a truthy value in the environment,
+    the spinner is not installed and SCons' default verbose output
+    is preserved.
+
+    Construction variables used:
+
+        SPINNER_DISABLE: If truthy, skip spinner setup entirely.
+            Useful for implementing a --verbose flag.
+
+        SPINNER_PREFIX: Optional string prepended to each line in
+            brackets, e.g. set to "arm" to get "[arm] Compiling ...".
+
+        PRINT_CMD_LINE_FUNC: Set to the spinner print function.
+
+    Environment methods added:
+
+        SpinnerAction(cmd, action_name, use_source=True):
+            Return an Action with spinner display for use in
+            custom Builder() definitions.
+    """
+    env.AddMethod(_spinner_action, 'SpinnerAction')
+
+    if env.get('SPINNER_DISABLE'):
+        return
+
+    project_root = env.Dir('#').get_abspath()
+    printer = SpinnerPrinter(project_root)
+    env['PRINT_CMD_LINE_FUNC'] = printer
+
+    for comstr_var, action_name, use_source in _STANDARD_BUILDERS:
+        env[comstr_var] = spinner_comstr(action_name, use_source)
+
+
+def exists(env):
+    """This tool has no external dependencies; it is always available."""
+    return True


### PR DESCRIPTION
## Summary

- Adds a new `spinner` tool that replaces verbose build output with compact, single-line status messages (e.g. `Compiling src/main.c`) that overwrite each other in-place, similar to CMake/Ninja output
- Covers all standard builders (C/C++, Fortran, Lex/Yacc, Java, linker, archiver, install)
- Provides `SpinnerAction()` env method for custom builders and `env.Command()` calls
- Supports `SPINNER_PREFIX` for multi-platform build distinction (e.g. `[arm] Compiling ...`)
- Supports `SPINNER_DISABLE` for verbose/debug mode
- Falls back to one-line-per-step output in non-TTY environments (CI, pipes)

## Test plan

- [ ] Verify spinner output on a TTY with standard C/C++ builders
- [ ] Verify `SPINNER_DISABLE` shows raw commands
- [ ] Verify `SpinnerAction` works with custom `Builder()` and `env.Command()`
- [ ] Verify `SPINNER_PREFIX` displays platform tags
- [ ] Verify non-TTY fallback (pipe output to `cat`)
- [ ] Verify `PRETEND_ISATTY=true` forces ANSI output in non-TTY